### PR TITLE
Never use '/usr' as default prefix for manual installation scripts

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 cd ./tmp
-cmake ../ -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DLIB_INSTALL_DIR=lib -DKDE_INSTALL_USE_QT_SYS_PATHS=ON
+cmake ../ -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_BUILD_TYPE=Release -DLIB_INSTALL_DIR=lib -DKDE_INSTALL_USE_QT_SYS_PATHS=ON
 make
 sudo make install
 cd ../


### PR DESCRIPTION
Usign `/usr` as PREFIX for an installation script which is intended to be executed by a user is a very bad practice - `/usr` is the package manager's realm.

Every manually built/managed file should go somewhere else (e.g. `/usr/local`).
